### PR TITLE
EIPs can have tags now. Instructions have been adjusted

### DIFF
--- a/cloudformation/demo-stack.yaml
+++ b/cloudformation/demo-stack.yaml
@@ -13,23 +13,26 @@ Resources:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        -
+          Key: "elastic-ip-manager-pool"
+          Value: bastion
   EIP2:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
-
-
-  EIPBastionPoolTags:
-    Type: Custom::Tag
-    Properties:
-      ResourceARN:
-        - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:eip/${EIP1.AllocationId}'
-        - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:eip/${EIP2.AllocationId}'
       Tags:
-        elastic-ip-manager-pool: bastion
-
-      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:cfn-tag-provider'
-
+        -
+          Key: "elastic-ip-manager-pool"
+          Value: bastion
+  EIP3:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        -
+          Key: "elastic-ip-manager-pool"
+          Value: bastion
 
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/cloudformation/elastic-ip-pool.yaml
+++ b/cloudformation/elastic-ip-pool.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Elastic IP pool for tagged hosts
+
+Parameters:
+  PoolName:
+    Type: String
+    Default: ''
+    Description: Instances with a elastic-ip-manager-pool tag with this value, will get EIP's from this pool
+
+Resources:
+  EIP1:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+         -
+          Key: "elastic-ip-manager-pool"
+          Value: !Ref PoolName
+  EIP2:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+         -
+            Key: "elastic-ip-manager-pool"
+            Value: !Ref PoolName
+  EIP3:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+         -
+           Key: "elastic-ip-manager-pool"
+           Value: !Ref PoolName


### PR DESCRIPTION
As EIPs can have tags now, the process of setting up the elastic-ip-manager is somewhat simpler.

I've adjusted the instruction about how to deploy from the aws-cli too.

In the case where an autoscaling group with instances is already present, the instructions for tagging everything correctly, after creating an EIP pool, has been supplied too.