### PR TITLE
Suggestion: Adding Terraform module + demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,8 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*

--- a/README.md
+++ b/README.md
@@ -74,18 +74,33 @@ If an auto scaling group with instances already exist,
 That is all. If you want to see it all in action, deploy the demo.
 
 ## Deploy the demo
-In order to deploy the demo, type:
 
+### Using CloudFormation Stack
+
+Run these commands to deploy the demo using CloudFormation Stack:
 ```sh
 export VPC_ID=$(aws ec2  --output text --query 'Vpcs[?IsDefault].VpcId' describe-vpcs)
 export SUBNET_IDS=$(aws ec2 describe-subnets --output text \
---filters Name=vpc-id,Values=$VPC_ID Name=default-for-az,Values=true --query 'Subnets[?MapPublicIpOnLaunch].SubnetId' | \
-tr '\t', '\,')
+  --filters Name=vpc-id,Values=$VPC_ID Name=default-for-az,Values=true --query 'Subnets[?MapPublicIpOnLaunch].SubnetId' \
+  | tr '\t', '\,')
 
-aws cloudformation create-stack --stack-name elastic-ip-manager-demo\
-     --template-body file://./cloudformation/demo-stack.yaml\
+aws cloudformation create-stack --stack-name elastic-ip-manager-demo \
+     --template-body file://./cloudformation/demo-stack.yaml \
      --parameters ParameterKey=VPC,ParameterValue=$VPC_ID ParameterKey=Subnets,ParameterValue=\"$SUBNET_IDS\"
+```
 
+### Using terraform
+
+Make sure you have terraform 0.12+ installed and run these commands:
+```sh
+export VPC_ID=$(aws ec2  --output text --query 'Vpcs[?IsDefault].VpcId' describe-vpcs)
+export SUBNET_LIST=$(aws ec2 describe-subnets --output json \
+  --filters Name=vpc-id,Values=$VPC_ID Name=default-for-az,Values=true --query 'Subnets[?MapPublicIpOnLaunch].SubnetId' \
+  | tr -d '\n ')
+
+cd ./terraform/demo
+terraform init
+terraform apply -var="vpc_id=$VPC_ID" -var="subnets=$SUBNET_LIST"
 ```
 
 ## Alternatives

--- a/terraform/demo/README.md
+++ b/terraform/demo/README.md
@@ -1,0 +1,23 @@
+# Demo of elastic-ip-manager by Terraform
+
+That is a simple configuration allowing to deploy a demo stack of elastip-ip-manager to AWS.
+
+It creates:
+- The pool of 3 ElasticIPs
+- Auto Scaling Group of 3 instances
+- AWS Lambda function for elastic-ip-manager
+- CloudWatch Event Rules and Targets for triggering the elastic-ip-manager Lambda function
+
+## Requirements
+
+- `terraform` 0.12.6 of higher (http://terraform.io/)
+
+## Usage
+
+This demo stack is designed to be deployed in the existing VPC.
+You should provide the VPC ID and the list of public subnet IDS using variables, for example:
+
+```
+terraform init
+terraform apply -var='vpc_id=vpc-1a2b3c4d5f' -var='subnets=["subnet-1a2b3c4d", "subnet-5e6f7g8h"]'
+```

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -1,0 +1,99 @@
+terraform {
+  required_version = ">= 0.12.6"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploy a demo ElasticIP pool
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_eip" "demo" {
+  count = 3
+
+  vpc = true
+
+  tags = merge(var.tags, {
+    Name                    = "demo-elastic-ip-manager"
+    elastic-ip-manager-pool = "bastion"
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploy a demo Auto Scaling Group
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "bastion" {
+  name        = "demo-elastic-ip-manager-bastion"
+  description = "Demo Security Group for Bastion host"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow SSH from the internet"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow ping from the internet"
+    from_port   = "-1"
+    to_port     = "-1"
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+data "aws_ami" "amazon_linux" {
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_launch_template" "demo" {
+  name_prefix   = "demo-elastic-ip-manager"
+  image_id      = data.aws_ami.amazon_linux.id
+  instance_type = "t2.micro"
+
+  network_interfaces {
+    security_groups             = [aws_security_group.bastion.id]
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = merge(var.tags, {
+      elastic-ip-manager-pool = "bastion"
+    })
+  }
+
+  tags = var.tags
+}
+
+resource "aws_autoscaling_group" "demo" {
+  name_prefix         = "demo-elastic-ip-manager"
+  vpc_zone_identifier = var.subnets
+  desired_capacity    = 3
+  max_size            = 3
+  min_size            = 1
+
+  launch_template {
+    id      = aws_launch_template.demo.id
+    version = "$Latest"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploy elastic-ip-manager Lambda function and all related resources
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "elastic_ip_manager" {
+  source = "../modules/elastic-ip-manager"
+
+  tags = var.tags
+}

--- a/terraform/demo/variables.tf
+++ b/terraform/demo/variables.tf
@@ -1,0 +1,24 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "vpc_id" {
+  description = "The ID of VPC to use in demo AutoScalingGroup"
+  type        = string
+}
+
+variable "subnets" {
+  description = "The list of subnets to use in demo AutoScalingGroup"
+  type        = list(string)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "tags" {
+  description = "A map of tags to add to all created resources"
+  default     = {}
+}

--- a/terraform/modules/elastic-ip-manager/README.md
+++ b/terraform/modules/elastic-ip-manager/README.md
@@ -1,0 +1,42 @@
+# Terraform module for elastip-ip-manager
+
+Terraform module which deploys `elastip-ip-manager` and all required resources to AWS.
+
+These types of resources are managed by this module:
+* [IAM Role](https://www.terraform.io/docs/providers/aws/r/iam_role.html)
+* [IAM Policy](https://www.terraform.io/docs/providers/aws/r/iam_policy.html)
+* [Lambda Function](https://www.terraform.io/docs/providers/aws/r/lambda_function.html)
+* [Lambda Permission](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)
+* [CloudWatch Event Rule](https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_rule.html)
+* [CloudWatch Event Target](https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html)
+
+## Terraform Version
+
+This module supports Terraform 0.12.6 and higher
+
+## Usage
+
+The module contains all sane defaults, so no variables are required:
+```hcl
+module "elastic_ip_manager" {
+  source = "git@github.com:binxio/ec2-elastic-ip-manager.git//terraform/modules/elastic-ip-manager"
+}
+```
+
+But if you want, you can customize any variables. You can find all supported variables and their descriptions
+in `./variables.tf`
+
+### Use custom S3 bucket and tags
+
+```hcl
+module "elastic_ip_manager" {
+  source = "git@github.com:binxio/ec2-elastic-ip-manager.git//terraform/modules/elastic-ip-manager"
+
+  s3_bucket = "my-org-bucket"
+  s3_key    = "path/to/elastic-ip-manager-latest.zip"
+
+  tags = {
+    CreatedBy = "terraform"
+  }
+}
+```

--- a/terraform/modules/elastic-ip-manager/main.tf
+++ b/terraform/modules/elastic-ip-manager/main.tf
@@ -1,0 +1,131 @@
+terraform {
+  required_version = ">= 0.12.6"
+}
+
+data "aws_region" "current" {}
+
+# Determine the default S3 bucket name for the corresponding region
+locals {
+  s3_bucket = coalesce(var.s3_bucket, "binxio-public-${data.aws_region.current.name}")
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM Policy and Role
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "elastic_ip_manager" {
+  statement {
+    actions = [
+      "ec2:DescribeAddresses",
+      "ec2:DescribeInstances",
+      "ec2:AssociateAddress",
+      "ec2:DisassociateAddress",
+      "tag:GetTagValues"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "elastic_ip_manager" {
+  name        = var.name
+  description = "The policy allowing elastic-ip-manager lambda function to manage ElasticIP addresses on EC2 instances"
+  policy      = data.aws_iam_policy_document.elastic_ip_manager.json
+}
+
+resource "aws_iam_role" "elastic_ip_manager" {
+  name               = var.name
+  description        = "The role which can be assumed by elastic-ip-manager lambda function"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "elastic_ip_manager" {
+  role       = aws_iam_role.elastic_ip_manager.name
+  policy_arn = aws_iam_policy.elastic_ip_manager.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  role       = aws_iam_role.elastic_ip_manager.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS Lambda Function
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_lambda_function" "elastic_ip_manager" {
+  function_name = var.name
+  description   = "ElasticIP manager for Auto Scaling Group instances"
+  role          = aws_iam_role.elastic_ip_manager.arn
+
+  s3_bucket = local.s3_bucket
+  s3_key    = var.s3_key
+
+  handler = "elastic_ip_manager.handler"
+  runtime = "python3.7"
+  timeout = 600
+
+  tags = var.tags
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_events" {
+  statement_id  = "AllowExecutionFromCloudWatchEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.elastic_ip_manager.function_name
+  principal     = "events.amazonaws.com"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS CloudWatch Event Rules to trigger Lambda Function
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_event_rule" "periodic_sync" {
+  name                = "${var.name}-periodic-sync"
+  description         = "Run a periodic elastic-ip-manager sync"
+  schedule_expression = "rate(5 minutes)"
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "periodic_sync" {
+  target_id = "${var.name}-periodic-sync"
+  rule      = aws_cloudwatch_event_rule.periodic_sync.name
+  arn       = aws_lambda_function.elastic_ip_manager.arn
+}
+
+resource "aws_cloudwatch_event_rule" "triggered_sync" {
+  name        = "${var.name}-triggered-sync"
+  description = "Run a elastic-ip-manager sync triggered by the event"
+
+  event_pattern = <<-EOS
+    {
+      "source": [
+        "aws.ec2"
+      ],
+      "detail-type": [
+        "EC2 Instance State-change Notification"
+      ]
+    }
+    EOS
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "triggered_sync" {
+  target_id = "${var.name}-triggered-sync"
+  rule      = aws_cloudwatch_event_rule.triggered_sync.name
+  arn       = aws_lambda_function.elastic_ip_manager.arn
+}

--- a/terraform/modules/elastic-ip-manager/outputs.tf
+++ b/terraform/modules/elastic-ip-manager/outputs.tf
@@ -1,0 +1,14 @@
+output "lambda_function_arn" {
+  value       = aws_lambda_function.elastic_ip_manager.arn
+  description = "ARN of created AWS Lambda function"
+}
+
+output "lambda_function_name" {
+  value       = aws_lambda_function.elastic_ip_manager.function_name
+  description = "The name of created AWS Lambda function"
+}
+
+output "iam_role_name" {
+  value       = aws_iam_role.elastic_ip_manager.name
+  description = "The name of created IAM Role"
+}

--- a/terraform/modules/elastic-ip-manager/variables.tf
+++ b/terraform/modules/elastic-ip-manager/variables.tf
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  type        = string
+  description = "The common name used as a base for all created resources"
+  default     = "elastic-ip-manager"
+}
+
+variable "s3_bucket" {
+  type        = string
+  description = "The S3 bucket containing the elastic-ip-manager function's deployment package. If ommited, the public bucket from binxio will be used."
+  default     = null
+}
+
+variable "s3_key" {
+  type        = string
+  description = "The S3 key of an object containing the elastic-ip-manager function's deployment package"
+  default     = "lambdas/elastic-ip-manager-0.1.6.zip"
+}
+
+variable "tags" {
+  description = "A map of tags to add to all created resources"
+  default     = {}
+}


### PR DESCRIPTION
Hi @mvanholsteijn,

Thank you for you work on `elastic-ip-manager` and the demo configuration you have published! It works great! 🎉 

Since I don't use CloudFormation and prefer terraform instead, I created the terraform module which does pretty much the same as your CloudFormation stack in `elastic-ip-manager.yaml`.

I thought it might be useful for others as well, because with terraform it's quite easy to refer to the external modules. So I decided to send this PR to include the terraform stuff into your upstream repo.

But if you feel that it's not what you want to keep and maintain in your repo - no problem, I can publish it separately. Thanks again for your project! 👍 


## Details
This PR contains 2 logical parts:
- the generic terraform module `./terraform/modules/elastic-ip-manager`, allowing to deploy "elastic-ip-manager" in any existing AWS infrastructure using terraform. 
- the demo stack `./terraform/demo`, allowing to deploy the demo with EIPs and ASG, as well as `elastic-ip-manager` using the module mentioned above.
